### PR TITLE
Added "ember-addon" config to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "dependencies": {
     "broccoli-gzip": "^0.2.0",
     "connect-gzip-static": "^1.0.0"
+  },
+  "ember-addon": {
+    "after": "broccoli-asset-rev"
   }
 }


### PR DESCRIPTION
- Includes use of the "after" hook to specify that ember-cli-gzip should
  be executed after broccoli-asset-rev
- Creates support for using broccoli-asset-rev (fingerprinting)
  alongside gzipping (this is a smart default)
