### PR TITLE
ember-cli-rsi should run before gzip, otherwhise the generated hash w…

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "connect-gzip-static": "^1.0.0"
   },
   "ember-addon": {
-    "after": "broccoli-asset-rev"
+    "after": [
+      "broccoli-asset-rev",
+      "ember-cli-sri"
+    ]
   }
 }


### PR DESCRIPTION
Hey @gdub22 

Ember-cli 1.13.5 made [ember-cli-sri](https://github.com/jonathanKingston/ember-cli-sri) a default. And a couple of days ago Chrome 45 was released checking SRI by default.

Projects that use both ember-cli-sri (which should be all, since ember-cli 1.13.5) and ember-cli-gzip will not work because if ember-cli-gzip runs before ember-cli-sri the generated hash is wrong and the browser won't allow the resource to load.

This pull request fix the issue by adding ember-cli-sri in the after list. I also opened a [pull request](https://github.com/jonathanKingston/ember-cli-sri/pull/7) for ember-cli-sri, I think this should be reinforced in both sides.

Thanks,

