### PR TITLE
broccoli-gzip 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/gdub22/ember-cli-gzip",
   "dependencies": {
-    "broccoli-gzip": "^0.2.0"
+    "broccoli-gzip": "^0.3.0"
   },
   "ember-addon": {
     "after": [


### PR DESCRIPTION
Fixes warnings when running `ember build`

```
 Warning: The .read and .rebuild APIs will stop working in the next Broccoli version
[API] Warning: Use broccoli-plugin instead: https://github.com/broccolijs/broccoli-plugin
[API] Warning: Plugin uses .read/.rebuild API: GzipFilter
```